### PR TITLE
HomePage 파트별 커리큘럼 navigate 로직 추가

### DIFF
--- a/src/components/SegmentBar.jsx
+++ b/src/components/SegmentBar.jsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 
 
-const SegmentBar = ({ items = [], styleType = 1, onSelect, style, className }) => {
-  const [activeIndex, setActiveIndex] = useState(0);
+const SegmentBar = ({ items = [], styleType = 1, onSelect, style, className, selected }) => {
+  const [activeIndex, setActiveIndex] = useState(selected ?? 0);
   const [isMobile, setIsMobile] = useState(window.innerWidth <= 799);
 
   useEffect(() => {
@@ -14,6 +14,12 @@ const SegmentBar = ({ items = [], styleType = 1, onSelect, style, className }) =
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
   }, []);
+
+  useEffect(() => {
+    if (selected !== undefined && selected !== activeIndex) {
+      setActiveIndex(selected);
+    }
+  }, [selected]);
 
   const handleClick = (index) => {
     setActiveIndex(index);

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 import IntroSection from "./IntroSection";
 import IntroSection2 from "./IntroSection2";
@@ -6,6 +7,16 @@ import EndSection from "./EndSection";
 import HomeMid from "./HomeMid";
 
 const Home = () => {
+  const location = useLocation();
+  
+  useEffect(() => {
+    if (location.hash === '#curriculum') {
+      document.getElementById('curriculum')?.scrollIntoView({ 
+        behavior: 'smooth' 
+      });
+    }
+  }, [location]);
+
   return (
     <PageContainer>
       <IntroSection />

--- a/src/pages/home/HomeMid.jsx
+++ b/src/pages/home/HomeMid.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import styled from "styled-components";
 import SegmentBar from "@/components/SegmentBar";
 import Curriculum from "@/components/Curriculum";
@@ -8,6 +8,8 @@ import Carousel2 from "@/components/carousel/Carousel2";
 import { intercollegiates } from "@/data";
 
 const HomeMid = () => {
+  const [searchParams] = useSearchParams();
+  
   // part: 'pm', 'fe', 'be' 중 하나
   const [part, setPart] = useState('pm');
   // SegmentBar 인덱스와 part 매핑
@@ -28,6 +30,13 @@ const HomeMid = () => {
     return () => window.removeEventListener("resize", handleResize);
   }, []);
 
+  useEffect(() => {
+    const partParam = searchParams.get('part');
+    if (partParam && partMap.includes(partParam)) {
+      setPart(partParam);
+    }
+  }, [searchParams]);
+
   const navigate = useNavigate();
 
   const handleProjectMore = () => {
@@ -36,7 +45,7 @@ const HomeMid = () => {
 
   return (
     <Wrapper>
-      <Section className="curriculum">
+      <Section className="curriculum" id="curriculum">
         <img src="/icons/logoIcon.svg" className="logo-icon"/>
         <Title className="point-eng-h2">curriculum</Title>
         <SubTitle className={isMobile ? "point-kor-h5" : "point-kor-h3"}>처음부터 차근 차근, 기초부터 심화까지</SubTitle>
@@ -45,6 +54,7 @@ const HomeMid = () => {
           items={['기획•디자인', '프론트엔드', '백엔드']}
           styleType={2}
           onSelect={handleSelect}
+          selected={partMap.indexOf(part)}
         />
         <Curriculum part={part}/>
       </Section>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->
- close #56 

## ✨ 작업 내용
<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->
아래 경로로 이동 시, 홈페이지의 해당 파트 커리큘럼으로 이동
```jsx
// 기획•디자인 커리큘럼으로 이동
navigate('/?part=pm#curriculum');

// 프론트엔드 커리큘럼으로 이동
navigate('/?part=fe#curriculum');

// 백엔드 커리큘럼으로 이동
navigate('/?part=be#curriculum');
```

## 📸 UI 작업 시
<!-- 이미지 or 영상 첨부 -->
- 기획•디자인 커리큘럼으로 이동
   https://likelion-ewha-website-front-5gbrhvw7e.vercel.app/?part=pm#curriculum
- 프론트엔드 커리큘럼으로 이동
   https://likelion-ewha-website-front-5gbrhvw7e.vercel.app/?part=fe#curriculum
- 백엔드 커리큘럼으로 이동
   https://likelion-ewha-website-front-5gbrhvw7e.vercel.app/?part=be#curriculum


## ✅ 체크 리스트
- [x] main 브랜치 pull 완료
- [x] Reviewers 설정
- [x] Assignees 설정
- [x] Labels 설정
- [x] Milestone 설정
