### PR TITLE
💄PC footer padding 수정

### DIFF
--- a/src/components/navigation/bottombar.jsx
+++ b/src/components/navigation/bottombar.jsx
@@ -60,24 +60,29 @@ const Footer = styled.footer`
   background: var(--neutral-15, #1c1c1c);
 `;
 
-/* MO 공통 시작점: 좌우 20px 기준선 */
+/* MO 시작점: 좌우 20px 패딩 */
+// PC 시작점: 좌우 80px 패딩
 const Inner = styled.div`
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   width: 100%;
+  max-width: 1159px;
+  margin: 0 auto;
 
+  /* MO: ~799px */
+  padding: 24px 20px 40px;
+  gap: 17px;
+  align-items: flex-start;
+
+  /* PC: 800px~ */
   @media (min-width: 800px) {
-    max-width: 970px;
-    padding: 40px 0;
-    gap: 32px;
-  }
-
-  @media (max-width: 799px) {
-    padding: 24px 20px 40px;
-    gap: 17px;
-    align-items: flex-start;
+    padding: 40px 80px;
+    gap: 10px;
+    align-items: center;
   }
 `;
+
 
 const TopRow = styled.div`
   display: flex;


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->
- close #76 

## ✨ 작업 내용
<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->
- PC footer에 연서님의 요청사항 반영
   - pc 화면 기준 footer의 패딩값 80px 반영
-  `const Inner = styled.div` 만 수정되었습니다!

## 📸 UI 작업 시
<!-- 이미지 or 영상 첨부 -->
<img width="717" height="864" alt="image" src="https://github.com/user-attachments/assets/9127614e-322d-4316-b506-60ce23597818" />


## ✅ 체크 리스트
- [ ] main 브랜치 pull 완료
- [x] Reviewers 설정
- [x] Assignees 설정
- [x] Labels 설정
- [x] Milestone 설정
